### PR TITLE
Add deployment step definition

### DIFF
--- a/vars/deployment.groovy
+++ b/vars/deployment.groovy
@@ -1,0 +1,56 @@
+def call(String repo, String environment, String url, Closure body) {
+  def deployID = ""
+
+  def createDeployment = """
+    set -eu
+
+    # Create Github Deployment & get the deployment ID
+    curl --request POST \
+      --url https://api.github.com/repos/adhocteam/${repo}/deployments \
+      --header 'accept: application/vnd.github.ant-man-preview+json' \
+      --header "authorization: token \$GH_TOKEN" \
+      --header 'content-type: application/json' \
+      --data '{
+        "ref": "${CHANGE_BRANCH}",
+        "environment": "${environment}",
+        "required_contexts": [],
+        "description": "Starting deployment for ${environment}"
+      }' | jq ".id"
+      """
+
+  def setStatus(String id, String status) {
+    return """
+      set -eu
+
+      curl --request POST \
+        --url "https://api.github.com/repos/adhocteam/${repo}/deployments/${id}/statuses" \
+        --header 'accept: application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json' \
+        --header "authorization: token \$GH_TOKEN" \
+        --header 'content-type: application/json' \
+        --data '{
+        "environment": "${environment}",
+        "state": "${status}",
+        "environment_url": "${url}",
+        "description": "Deployment to ${environment}: ${status}."
+        }'
+        """
+  }
+
+  try {
+    withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
+      deployID = sh(returnStdout: true, script: createDeployment).trim()
+    }
+    body.call()
+  } catch (e) {
+    script = setStatus(deployID, 'failure')
+    withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
+      sh script
+    }
+    throw e
+  }
+
+  script = setStatus(deployID, 'success')
+  withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
+    sh script
+  }
+}


### PR DESCRIPTION
### Adds deployment step

Related to https://github.com/adhocteam/people_ui/pull/51

This refactors the code Brooks created into a reusable step for our shared library

### Proposed changes:

- Pull out Brooks's code into a shared snippet

This creates a custom step in our jenkins setup that takes in 3 parameters and a block to run:

```groovy
      steps {
        deployment('people_ui',
                   'preview',
                   "http://preview.people.adhoc.team.s3-website-us-east-1.amazonaws.com/${CHANGE_ID}") {
          sh '''#!/bin/bash
            set -euxo pipefail

            # Build site & set preview paths
            docker run --rm -v $(pwd)/public:/site/public -e CUSTOM_PREFIX=$CHANGE_ID people_ui:latest gatsby build --prefix-paths

            # Deploy preview
            aws s3 sync public s3://preview.people.adhoc.team/$CHANGE_ID --delete --no-progress
            '''
        }
      }
```

This should allow us to re-use Brooks's code across our Jenkinsfiles while keeping them cleaner.

### Optional Details

#### Alternate Designs
We could use https://jenkins.io/doc/pipeline/steps/http_request/ instead of `curl` but not much benefit there and would require adding another plugin to our Jenkins setup.

#### Security implications

Jenkins should mask the token in our logs so we should be okay using this shelled out.

#### Requested feedback

I'm gonna merge this to test because Jenkins only pulls from the master branch :man_shrugging: 